### PR TITLE
Tweak `setActiveNavItem()` to account for optional "index.html"

### DIFF
--- a/src/assets/drizzle/scripts/drizzle.js
+++ b/src/assets/drizzle/scripts/drizzle.js
@@ -10,7 +10,8 @@ dom.navToggle = dom.nav.querySelector('a[href="#nav"]');
 dom.navLinks = dom.navMenu.querySelectorAll('a');
 
 function setActiveNavItem (pathname) {
-  const isMatch = a => a.pathname === pathname;
+  const noIndex = str => str.replace(/index\.html$/, '');
+  const isMatch = a => noIndex(a.pathname) === noIndex(pathname);
   const item = Array.from(dom.navLinks).find(isMatch);
   if (item) {
     item.classList.add('is-active');


### PR DESCRIPTION
Fixes #15 

This tweaks the funky JS used to set the active nav item. It now accounts for `/` as well as `/index.html` (and likewise for any directory, e.g. `/demos`).

![screen shot 2016-04-21 at 3 43 01 pm](https://cloud.githubusercontent.com/assets/61204/14726527/c2d4c6c6-07d7-11e6-8e86-59e8d2d46862.png)

/CC @mrgerardorodriguez 
