### PR TITLE
Clickable, iframe-based thumbnail pattern for page/demo indices

### DIFF
--- a/src/assets/drizzle/scripts/drizzle.js
+++ b/src/assets/drizzle/scripts/drizzle.js
@@ -24,3 +24,19 @@ dom.navToggle.addEventListener('click', event => {
 });
 
 setActiveNavItem(window.location.pathname);
+
+dom.frameContainers = document.querySelectorAll('[data-drizzle-append-iframe]');
+
+if (dom.frameContainers.length) {
+  window.addEventListener('load', () => {
+    Array.from(dom.frameContainers).forEach(container => {
+      const src = container.getAttribute('data-drizzle-append-iframe');
+      const iframe = document.createElement('iframe');
+      iframe.addEventListener('load', () => {
+        container.classList.add('is-loaded');
+      });
+      iframe.setAttribute('src', src);
+      container.appendChild(iframe);
+    });
+  });
+}

--- a/src/assets/drizzle/styles/components/frame-thumb.css
+++ b/src/assets/drizzle/styles/components/frame-thumb.css
@@ -27,17 +27,25 @@
   border: var(--FrameThumb-link-border);
 }
 
+/**
+ * 1. Multiply the dimenions of the iframe to counteract whatever scaling will
+ *    be applied via transform. 1% wiggle room is added to avoid blurry edges
+ *    along the top and bottom.
+ * 2. Scale the iframe back down to the container size. This gives us a "zoomed
+ *    out" view of the page within the thumbnail.
+ */
+
 .FrameThumb > iframe {
   position: absolute;
   top: 0;
   left: 0;
   visibility: hidden;
-  width: 201%;
-  height: 201%;
+  width: calc((1 / var(--FrameThumb-iframe-scale)) * 100% + 1%); /* 1 */
+  height: calc((1 / var(--FrameThumb-iframe-scale)) * 100% + 1%); /* 1 */
   border: 0;
   background: var(--FrameThumb-iframe-background);
-  transform: scale(var(--FrameThumb-iframe-scale));
-  transform-origin: top left;
+  transform: scale(var(--FrameThumb-iframe-scale)); /* 2 */
+  transform-origin: top left; /* 2 */
 }
 
 .FrameThumb.is-loaded > iframe {

--- a/src/assets/drizzle/styles/components/frame-thumb.css
+++ b/src/assets/drizzle/styles/components/frame-thumb.css
@@ -1,0 +1,45 @@
+:root {
+  --FrameThumb-background: no-repeat center/20% var(--FrameThumb-icon) var(--FrameThumb-background-color);
+  --FrameThumb-background-color: var(--color-silver);
+  --FrameThumb-icon: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 17 22' width='17' height='22' fill='white'><polygon points='0 0 10 0 10 7 17 7 17 22 0 22'/><polygon points='11 0 17 6 11 6'/></svg>");
+  --FrameThumb-ratio: calc(16 / 9);
+  --FrameThumb-link-border: 2px solid rgba(0,0,0,0.1);
+  --FrameThumb-iframe-background: var(--color-white);
+  --FrameThumb-iframe-scale: 0.5;
+}
+
+.FrameThumb {
+  position: relative;
+  overflow: hidden;
+  width: 100%;
+  height: 0;
+  padding-top: calc(1 / var(--FrameThumb-ratio) * 100%);
+  background: var(--FrameThumb-background);
+}
+
+.FrameThumb > a {
+  position: absolute;
+  z-index: 1;
+  top: 0;
+  right: 0;
+  bottom: 0;
+  left: 0;
+  border: var(--FrameThumb-link-border);
+}
+
+.FrameThumb > iframe {
+  position: absolute;
+  top: 0;
+  left: 0;
+  visibility: hidden;
+  width: 201%;
+  height: 201%;
+  border: 0;
+  background: var(--FrameThumb-iframe-background);
+  transform: scale(var(--FrameThumb-iframe-scale));
+  transform-origin: top left;
+}
+
+.FrameThumb.is-loaded > iframe {
+  visibility: visible;
+}

--- a/src/assets/drizzle/styles/components/index.css
+++ b/src/assets/drizzle/styles/components/index.css
@@ -1,3 +1,4 @@
+@import "./frame-thumb.css";
 @import "./item.css";
 @import "./label.css";
 @import "./layout.css";

--- a/src/pages/demos/demo-example-1.hbs
+++ b/src/pages/demos/demo-example-1.hbs
@@ -2,6 +2,9 @@
 title: Navigation A
 notes: This is an example demo.
 layout: blank
+labels:
+  - inprogress
+  - prototype
 styles:
   - demo-1
 ---

--- a/src/pages/demos/index.hbs
+++ b/src/pages/demos/index.hbs
@@ -2,12 +2,12 @@
 title: Demos
 ---
 
+<h1>Demos</h1>
+
 <p>These are some demos.</p>
 
-<ul>
-  {{#each drizzle.pages.demos}}
-    {{#compare @key "!==" "index"}}
-      <li><a href="./{{@key}}.html">{{data.title}}</a></li>
-    {{/compare}}
-  {{/each}}
-</ul>
+{{#each drizzle.pages.demos}}
+  {{#compare @key "!==" "index"}}
+    {{> drizzle.page-item }}
+  {{/compare}}
+{{/each}}

--- a/src/templates/drizzle/page-item.hbs
+++ b/src/templates/drizzle/page-item.hbs
@@ -1,0 +1,36 @@
+<div class="drizzle-Item">
+  <div class="drizzle-Grid drizzle-Grid--withGutter">
+    <div class="drizzle-Grid-cell drizzle-u-md-size1of3">
+      <div class="drizzle-FrameThumb" data-drizzle-append-iframe="./{{@key}}.html" aria-hidden="true">
+        <a href="./{{@key}}.html"></a>
+      </div>
+    </div>
+    <div class="drizzle-Grid-cell drizzle-u-md-size2of3">
+      <div class="drizzle-u-marginEnds">
+        <h4 class="
+         drizzle-u-inlineBlock
+         drizzle-u-alignMiddle
+         drizzle-u-textNoWrap
+         drizzle-u-padRight">
+          <a href="./{{@key}}.html">{{data.title}}</a>
+        </h4>
+        {{#if data.labels}}
+          <ul class="
+           drizzle-u-inlineBlock
+           drizzle-u-alignMiddle">
+            {{#each data.labels}}
+              <li class="drizzle-Label drizzle-Label--{{this}}">
+                {{this}}
+              </li>
+            {{/each}}
+          </ul>
+        {{/if}}
+      </div>
+      {{#if data.notes}}
+        <div class="drizzle-Item-notes drizzle-u-rhythm">
+          {{{data.notes}}}
+        </div>
+      {{/if}}
+    </div>
+  </div>
+</div>


### PR DESCRIPTION
This PR adds a new `page-item` partial, which leverages a new `FrameThumb` pattern. This displays the pages with an `iframe`-based thumbnail, similar to [CodePen](http://codepen.io/) and one of our old bespoke pattern libraries.

The biggest change from our previous implementations of this pattern are that the thumbnail itself is flexible, there's still plenty of room available for text-based descriptions, and loading of actual `iframe` elements is deferred till the rest of the page has loaded.
## Screenshots
### Narrow

![screencapture-localhost-3000-demos-index-html-1461363791669](https://cloud.githubusercontent.com/assets/69633/14756448/3a1dd0ee-089e-11e6-8562-829d1e80fbde.png)
### Wide

![screencapture-localhost-3000-demos-index-html-1461363816010](https://cloud.githubusercontent.com/assets/69633/14756451/3d598eba-089e-11e6-8bdb-5327da375795.png)

---

@mrgerardorodriguez @erikjung @saralohr @nicolemors @aileenjeffries 

Closes #8, See #19 
