### PR TITLE
Support previewClass in pattern frontmatter

### DIFF
--- a/src/patterns/typography/headings.hbs
+++ b/src/patterns/typography/headings.hbs
@@ -6,6 +6,7 @@ links:
   MDN: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/Heading_Elements
 labels:
   - inprogress
+previewClass: drizzle-u-rhythm
 ---
 
 {{#with drizzle.data.specimens.contents}}

--- a/src/patterns/typography/lists.hbs
+++ b/src/patterns/typography/lists.hbs
@@ -7,6 +7,7 @@ links:
   "MDN <ol>": https://developer.mozilla.org/en-US/docs/Web/HTML/Element/ol
 labels:
   - inprogress
+previewClass: drizzle-u-rhythm
 ---
 
 <ol>

--- a/src/templates/drizzle/item.hbs
+++ b/src/templates/drizzle/item.hbs
@@ -49,7 +49,7 @@
   {{/if}}
   {{!-- Preview --}}
   <div class="drizzle-u-border">
-    <div class="drizzle-u-pad drizzle-u-cf drizzle-u-posRelative">
+    <div class="drizzle-u-pad drizzle-u-cf drizzle-u-posRelative {{data.previewClass}}">
       {{{pattern id @root}}}
     </div>
     {{!-- Code sample --}}


### PR DESCRIPTION
Allows classes to be appended to container of pattern preview area.

Open to feedback on the name.

---

@erikjung @mrgerardorodriguez @saralohr @nicolemors 

Closes #24 
