### PR TITLE
Add missing package

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "eslint-config-xo-space": "^0.12.0",
     "eslint-plugin-babel": "^3.2.0",
     "gulp": "^3.9.1",
+    "gulp-util": "^3.0.7",
     "postcss-cssnext": "^2.5.2",
     "prismjs": "^1.4.1",
     "suitcss-base": "^2.0.0",


### PR DESCRIPTION
This has been missing, yet has somehow not resulted in any errors during local development so far (even though it's required by the Gulp file).

Maybe due to our global `gulp` installs? 

/CC @tylersticka @mrgerardorodriguez 
