### PR TITLE
Add new color swatches

### DIFF
--- a/src/assets/drizzle/styles/components/index.css
+++ b/src/assets/drizzle/styles/components/index.css
@@ -3,3 +3,4 @@
 @import "./label.css";
 @import "./layout.css";
 @import "./nav.css";
+@import "./swatch.css";

--- a/src/assets/drizzle/styles/components/swatch.css
+++ b/src/assets/drizzle/styles/components/swatch.css
@@ -1,0 +1,38 @@
+:root {
+  --Swatch-sample-stroke: rgba(0, 0, 0, 0.1);
+  --Swatch-sample-stroke-width: 2px;
+  --Swatch-sample-width: 10em;
+  --Swatch-sample-height: 5.625em;
+  --Swatch-info-padding: calc(var(--space) / 4);
+}
+
+.Swatch {
+  margin: 0;
+  display: inline-block;
+}
+
+.Swatch > * {
+  margin: 0;
+}
+
+/**
+ * 1. Double the intended stroke-width because only the inner half will be
+ *    within the visible viewBox.
+ */
+
+.Swatch-sample {
+  display: block;
+  width: var(--Swatch-sample-width);
+  height: var(--Swatch-sample-height);
+  stroke: rgba(0, 0, 0, 0.1);
+  stroke-width: calc(var(--Swatch-sample-stroke-width) * 2); /* 1 */
+}
+
+.Swatch-info {
+  padding: var(--Swatch-info-padding);
+}
+
+.Swatch-info > * {
+  margin: 0;
+  white-space: nowrap;
+}

--- a/src/assets/drizzle/styles/components/swatch.css
+++ b/src/assets/drizzle/styles/components/swatch.css
@@ -1,38 +1,19 @@
 :root {
-  --Swatch-sample-stroke: rgba(0, 0, 0, 0.1);
-  --Swatch-sample-stroke-width: 2px;
-  --Swatch-sample-width: 10em;
-  --Swatch-sample-height: calc(var(--Swatch-sample-width) * (9 / 16)); /* 16:9 */
-  --Swatch-info-padding: calc(var(--space) / 4);
-}
-
-.Swatch {
-  margin: 0;
-  display: inline-block;
-}
-
-.Swatch > * {
-  margin: 0;
+  --Swatch-width: 10em;
+  --Swatch-height: calc(var(--Swatch-width) * (9 / 16)); /* 16:9 */
+  --Swatch-stroke: rgba(0, 0, 0, 0.1);
+  --Swatch-stroke-width: 2px;
 }
 
 /**
- * 1. Double the intended stroke-width because only the inner half will be
+ * 1. Improves swatch visibility on low-contrast background colors.
+ * 2. Double the intended stroke-width because only the inner half will be
  *    within the visible viewBox.
  */
 
-.Swatch-sample {
-  display: block;
-  width: var(--Swatch-sample-width);
-  height: var(--Swatch-sample-height);
-  stroke: var(--Swatch-sample-stroke);
-  stroke-width: calc(var(--Swatch-sample-stroke-width) * 2); /* 1 */
-}
-
-.Swatch-info {
-  padding: var(--Swatch-info-padding);
-}
-
-.Swatch-info > * {
-  margin: 0;
-  white-space: nowrap;
+.Swatch {
+  width: var(--Swatch-width);
+  height: var(--Swatch-height);
+  stroke: var(--Swatch-stroke); /* 1 */
+  stroke-width: calc(var(--Swatch-stroke-width) * 2); /* 2 */
 }

--- a/src/assets/drizzle/styles/components/swatch.css
+++ b/src/assets/drizzle/styles/components/swatch.css
@@ -2,7 +2,7 @@
   --Swatch-sample-stroke: rgba(0, 0, 0, 0.1);
   --Swatch-sample-stroke-width: 2px;
   --Swatch-sample-width: 10em;
-  --Swatch-sample-height: 5.625em;
+  --Swatch-sample-height: calc(var(--Swatch-sample-width) * (9 / 16)); /* 16:9 */
   --Swatch-info-padding: calc(var(--space) / 4);
 }
 
@@ -24,7 +24,7 @@
   display: block;
   width: var(--Swatch-sample-width);
   height: var(--Swatch-sample-height);
-  stroke: rgba(0, 0, 0, 0.1);
+  stroke: var(--Swatch-sample-stroke);
   stroke-width: calc(var(--Swatch-sample-stroke-width) * 2); /* 1 */
 }
 

--- a/src/assets/drizzle/styles/utils/list.css
+++ b/src/assets/drizzle/styles/utils/list.css
@@ -1,9 +1,13 @@
+.u-listUnstyled,
+.u-listInline {
+  padding-left: 0;
+  list-style: none;
+}
+
 .u-listInline {
   position: relative;
   margin-right: -0.5em;
   margin-left: -0.5em;
-  padding-left: 0;
-  list-style: none;
 }
 
 .u-listInline > li {

--- a/src/assets/drizzle/styles/utils/space.css
+++ b/src/assets/drizzle/styles/utils/space.css
@@ -61,3 +61,33 @@
 .u-rhythm > * + * {
   margin-top: var(--space);
 }
+
+.u-noMargin {
+  margin: 0 !important;
+}
+
+.u-noMarginLeft {
+  margin-left: 0 !important;
+}
+
+.u-noMarginRight {
+  margin-right: 0 !important;
+}
+
+.u-noMarginSides {
+  margin-left: 0 !important;
+  margin-right: 0 !important;
+}
+
+.u-noMarginTop {
+  margin-top: 0 !important;
+}
+
+.u-noMarginBottom {
+  margin-bottom: 0 !important;
+}
+
+.u-noMarginEnds {
+  margin-bottom: 0 !important;
+  margin-top: 0 !important;
+}

--- a/src/assets/drizzle/styles/utils/type.css
+++ b/src/assets/drizzle/styles/utils/type.css
@@ -1,3 +1,7 @@
 .u-capitalize {
   text-transform: capitalize;
 }
+
+.u-textSmaller {
+  font-size: 0.875em;
+}

--- a/src/data/colors.yaml
+++ b/src/data/colors.yaml
@@ -1,0 +1,25 @@
+brand:
+  - color: "#001F3F"
+    property: "--color-navy"
+  - color: "#0074D9"
+    property: "--color-blue"
+  - color: "#7FDBFF"
+    property: "--color-aqua"
+  - color: "#39CCCC"
+    property: "--color-teal"
+
+grays:
+  - color: "#111111"
+    property: "--color-black"
+  - color: "#AAAAAA"
+    property: "--color-gray"
+  - color: "#DDDDDD"
+    property: "--color-silver"
+
+states:
+  - color: "#2ECC40"
+    property: "--color-green"
+  - color: "#FFDC00"
+    property: "--color-yellow"
+  - color: "#FF4136"
+    property: "--color-red"

--- a/src/pages/index.hbs
+++ b/src/pages/index.hbs
@@ -28,3 +28,16 @@ title: Overview
     anything else that might not be production-ready.
   </dd>
 </dl>
+
+<h3>Colors</h3>
+
+{{#each drizzle.data.colors.contents}}
+  <h4 class="drizzle-u-capitalize">{{@key}}</h4>
+  <ul class="drizzle-u-listInline">
+    {{#each this}}
+      <li class="drizzle-u-marginBottom">
+        {{> drizzle.swatch }}
+      </li>
+    {{/each}}
+  </ul>
+{{/each}}

--- a/src/templates/drizzle/swatch.hbs
+++ b/src/templates/drizzle/swatch.hbs
@@ -1,0 +1,14 @@
+<figure class="drizzle-Swatch">
+  <svg class="drizzle-Swatch-sample">
+    <rect fill="{{color}}" width="100%" height="100%"/>
+  </svg>
+  <figcaption class="drizzle-Swatch-info">
+    {{#if label}}
+      <p>{{label}}</p>
+    {{/if}}
+    <p><code>{{color}}</code></p>
+    {{#if property}}
+      <p><code>{{property}}</code></p>
+    {{/if}}
+  </figcaption>
+</figure>

--- a/src/templates/drizzle/swatch.hbs
+++ b/src/templates/drizzle/swatch.hbs
@@ -1,14 +1,12 @@
-<figure class="drizzle-Swatch">
-  <svg class="drizzle-Swatch-sample">
+<figure class="drizzle-u-noMarginLeft">
+  <svg class="drizzle-Swatch">
     <rect fill="{{color}}" width="100%" height="100%"/>
   </svg>
-  <figcaption class="drizzle-Swatch-info">
-    {{#if label}}
-      <p>{{label}}</p>
-    {{/if}}
-    <p><code>{{color}}</code></p>
-    {{#if property}}
-      <p><code>{{property}}</code></p>
-    {{/if}}
+  <figcaption class="drizzle-u-textSmaller">
+    <ul class="drizzle-u-listUnstyled">
+      {{#if label}}<li>{{label}}</li>{{/if}}
+      <li><code>{{color}}</code></li>
+      {{#if property}}<li><code>{{property}}</code></li>{{/if}}
+    </ul>
   </figcaption>
 </figure>


### PR DESCRIPTION
This PR reintroduces color swatches based on [this prototype](http://codepen.io/tylersticka/pen/QNzgVZ).

![screen shot 2016-05-05 at 11 54 05 am](https://cloud.githubusercontent.com/assets/69633/15053574/1aa0b4ba-12b8-11e6-8876-34ac6416da89.png)

I considered adding these to a new page (rather than the "Overview"), but because we lack control over a page order I wasn't able to succinctly modify the nav so that "Colors" came after "Overview." (See #42)

---

@erikjung @mrgerardorodriguez @saralohr @nicolemors 

Closes #34 
