### PR TITLE
Feature: Restructure `blank.hbs`

### DIFF
--- a/src/templates/blank.hbs
+++ b/src/templates/blank.hbs
@@ -22,7 +22,7 @@
 
       {{/block}}
     {{/block}}
-    {{#block "footer"}}
+    {{#block "foot"}}
 
     {{/block}}
   </body>

--- a/src/templates/blank.hbs
+++ b/src/templates/blank.hbs
@@ -21,9 +21,9 @@
       {{#block "body"}}
 
       {{/block}}
-      {{#block "footer"}}
+    {{/block}}
+    {{#block "footer"}}
 
-      {{/block}}
     {{/block}}
   </body>
 </html>

--- a/src/templates/blank.hbs
+++ b/src/templates/blank.hbs
@@ -16,11 +16,14 @@
       {{/each}}
     {{/block}}
   </head>
-  {{#block "wrapper"}}
-    <body>
+  <body class="{{bodyclass}}">
+    {{#block "wrapper"}}
       {{#block "body"}}
 
       {{/block}}
-    </body>
-  {{/block}}
+      {{#block "footer"}}
+
+      {{/block}}
+    {{/block}}
+  </body>
 </html>

--- a/src/templates/default.hbs
+++ b/src/templates/default.hbs
@@ -10,11 +10,11 @@
         {{#block "body"}}
 
         {{/block}}
-        {{#block "footer"}}
-          <script src="{{baseurl}}/assets/drizzle/scripts/drizzle.js"></script>
-          <script src="{{baseurl}}/assets/toolkit/scripts/toolkit.js"></script>
-        {{/block}}
       </div>
     </div>
+  {{/content}}
+  {{#content "footer"}}
+    <script src="{{baseurl}}/assets/drizzle/scripts/drizzle.js"></script>
+    <script src="{{baseurl}}/assets/toolkit/scripts/toolkit.js"></script>
   {{/content}}
 {{/extend}}

--- a/src/templates/default.hbs
+++ b/src/templates/default.hbs
@@ -10,11 +10,11 @@
         {{#block "body"}}
 
         {{/block}}
+        {{#block "footer"}}
+          <script src="{{baseurl}}/assets/drizzle/scripts/drizzle.js"></script>
+          <script src="{{baseurl}}/assets/toolkit/scripts/toolkit.js"></script>
+        {{/block}}
       </div>
     </div>
-    {{#content "footer"}}
-      <script src="{{baseurl}}/assets/drizzle/scripts/drizzle.js"></script>
-      <script src="{{baseurl}}/assets/toolkit/scripts/toolkit.js"></script>
-    {{/content}}
   {{/content}}
 {{/extend}}

--- a/src/templates/default.hbs
+++ b/src/templates/default.hbs
@@ -13,7 +13,7 @@
       </div>
     </div>
   {{/content}}
-  {{#content "footer"}}
+  {{#content "foot"}}
     <script src="{{baseurl}}/assets/drizzle/scripts/drizzle.js"></script>
     <script src="{{baseurl}}/assets/toolkit/scripts/toolkit.js"></script>
   {{/content}}

--- a/src/templates/default.hbs
+++ b/src/templates/default.hbs
@@ -1,20 +1,20 @@
-{{#extend "blank" htmlclass="drizzle-Layout"}}
+{{#extend "blank" htmlclass="drizzle-Layout" bodyclass="drizzle-Layout-body"}}
   {{#content "head" mode="append"}}
     <link rel="stylesheet" href="{{baseurl}}/assets/drizzle/styles/drizzle.css">
     <link rel="stylesheet" href="{{baseurl}}/assets/toolkit/styles/toolkit.css">
   {{/content}}
   {{#content "wrapper"}}
-    <body class="drizzle-Layout-body">
-      {{> drizzle.nav}}
-      <div class="drizzle-Layout-main drizzle-u-cf">
-        <div class="drizzle-u-pad drizzle-u-rhythm">
-          {{#block "body"}}
+    {{> drizzle.nav}}
+    <div class="drizzle-Layout-main drizzle-u-cf">
+      <div class="drizzle-u-pad drizzle-u-rhythm">
+        {{#block "body"}}
 
-          {{/block}}
-        </div>
+        {{/block}}
       </div>
+    </div>
+    {{#content "footer"}}
       <script src="{{baseurl}}/assets/drizzle/scripts/drizzle.js"></script>
       <script src="{{baseurl}}/assets/toolkit/scripts/toolkit.js"></script>
-    </body>
+    {{/content}}
   {{/content}}
 {{/extend}}


### PR DESCRIPTION
Per the comment [here](https://github.com/cloudfour/drizzle/issues/19#issuecomment-218584444), this PR restructures the `blank.hbs` template and adds a blank `foot` block.

cc: @tylersticka @erikjung 
