### PR TITLE
Chore: Adjust Page item and label header quirks

### DIFF
--- a/src/assets/drizzle/styles/utils/space.css
+++ b/src/assets/drizzle/styles/utils/space.css
@@ -28,36 +28,6 @@
   padding-top: var(--space) !important;
 }
 
-.u-noPad {
-  padding: 0 !important;
-}
-
-.u-noPadLeft {
-  padding-left: 0 !important;
-}
-
-.u-noPadRight {
-  padding-right: 0 !important;
-}
-
-.u-noPadSides {
-  padding-left: 0 !important;
-  padding-right: 0 !important;
-}
-
-.u-noPadTop {
-  padding-top: 0 !important;
-}
-
-.u-noPadBottom {
-  padding-bottom: 0 !important;
-}
-
-.u-noPadEnds {
-  padding-bottom: 0 !important;
-  padding-top: 0 !important;
-}
-
 .u-margin {
   margin: var(--space) !important;
 }

--- a/src/assets/drizzle/styles/utils/space.css
+++ b/src/assets/drizzle/styles/utils/space.css
@@ -28,6 +28,36 @@
   padding-top: var(--space) !important;
 }
 
+.u-noPad {
+  padding: 0 !important;
+}
+
+.u-noPadLeft {
+  padding-left: 0 !important;
+}
+
+.u-noPadRight {
+  padding-right: 0 !important;
+}
+
+.u-noPadSides {
+  padding-left: 0 !important;
+  padding-right: 0 !important;
+}
+
+.u-noPadTop {
+  padding-top: 0 !important;
+}
+
+.u-noPadBottom {
+  padding-bottom: 0 !important;
+}
+
+.u-noPadEnds {
+  padding-bottom: 0 !important;
+  padding-top: 0 !important;
+}
+
 .u-margin {
   margin: var(--space) !important;
 }

--- a/src/templates/drizzle/labelheader.hbs
+++ b/src/templates/drizzle/labelheader.hbs
@@ -1,7 +1,6 @@
 <{{tag}} {{#if id}}id="{{id}}"{{/if}} class="
   drizzle-u-inlineBlock
   drizzle-u-alignMiddle
-  drizzle-u-textNoWrap
   drizzle-u-padRight">
   {{#if id}}
     <a href="#{{id}}" class="drizzle-u-linkHidden">{{> @partial-block }}</a>

--- a/src/templates/drizzle/labelheader.hbs
+++ b/src/templates/drizzle/labelheader.hbs
@@ -12,7 +12,7 @@
   <ul class="
     drizzle-u-inlineBlock
     drizzle-u-alignMiddle
-    drizzle-u-noPadLeft">
+    drizzle-u-listUnstyled">
     {{#each labels as |label|}}
       <li class="drizzle-Label drizzle-Label--{{label}}">
         {{label}}

--- a/src/templates/drizzle/labelheader.hbs
+++ b/src/templates/drizzle/labelheader.hbs
@@ -11,7 +11,8 @@
 {{#if labels}}
   <ul class="
     drizzle-u-inlineBlock
-    drizzle-u-alignMiddle">
+    drizzle-u-alignMiddle
+    drizzle-u-noPadLeft">
     {{#each labels as |label|}}
       <li class="drizzle-Label drizzle-Label--{{label}}">
         {{label}}

--- a/src/templates/drizzle/page-item.hbs
+++ b/src/templates/drizzle/page-item.hbs
@@ -1,16 +1,14 @@
 <div class="drizzle-Item">
   <div class="drizzle-Grid drizzle-Grid--withGutter">
-    <div class="drizzle-Grid-cell drizzle-u-md-size1of3">
+    <div class="drizzle-Grid-cell drizzle-u-marginBottom drizzle-u-md-size1of3">
       <div class="drizzle-FrameThumb" data-drizzle-append-iframe="./{{@key}}.html" aria-hidden="true">
         <a href="./{{@key}}.html"></a>
       </div>
     </div>
     <div class="drizzle-Grid-cell drizzle-u-md-size2of3">
-      <div class="drizzle-u-marginEnds">
-        {{#> drizzle.labelheader tag="h4" labels=data.labels}}
-          <a href="./{{@key}}.html">{{data.title}}</a>
-        {{/drizzle.labelheader}}
-      </div>
+      {{#> drizzle.labelheader tag="h4" labels=data.labels}}
+        <a href="./{{@key}}.html">{{data.title}}</a>
+      {{/drizzle.labelheader}}
       {{#if data.notes}}
         <div class="drizzle-Item-notes drizzle-u-rhythm">
           {{{data.notes}}}


### PR DESCRIPTION
This PR addresses https://github.com/cloudfour/drizzle/issues/28.

Changes include:
- Add `noPad*` utility classes
- Moves `margin` to below thumbs
- Remove left-padding on labels
- Allow pattern headings to wrap

cc: @tylersticka @erikjung @nicolemors @saralohr 

closes https://github.com/cloudfour/drizzle/issues/28
