### PR TITLE
Chore: Update to latest `drizzle-builder`

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "babel-preset-es2015": "^6.6.0",
     "core-gulp-tasks": "github:cloudfour/core-gulp-tasks#v2.0.0",
     "core-hbs-helpers": "github:cloudfour/core-hbs-helpers#v0.4.0",
-    "drizzle-builder": "0.0.2-alpha",
+    "drizzle-builder": "0.0.5",
     "eslint": "^2.7.0",
     "eslint-config-xo-space": "^0.12.0",
     "eslint-plugin-babel": "^3.2.0",

--- a/src/templates/blank.hbs
+++ b/src/templates/blank.hbs
@@ -17,8 +17,8 @@
     {{/block}}
   </head>
   <body class="{{bodyclass}}">
-    {{#block "wrapper"}}
-      {{#block "body"}}
+    {{#block "body"}}
+      {{#block "main"}}
 
       {{/block}}
     {{/block}}

--- a/src/templates/collection.hbs
+++ b/src/templates/collection.hbs
@@ -1,5 +1,5 @@
 {{#extend "default"}}
-  {{#content "body"}}
+  {{#content "main"}}
     <h1>{{name}}</h1>
     {{#each patterns}}
       {{> drizzle.item}}

--- a/src/templates/default.hbs
+++ b/src/templates/default.hbs
@@ -3,11 +3,11 @@
     <link rel="stylesheet" href="{{baseurl}}/assets/drizzle/styles/drizzle.css">
     <link rel="stylesheet" href="{{baseurl}}/assets/toolkit/styles/toolkit.css">
   {{/content}}
-  {{#content "wrapper"}}
+  {{#content "body"}}
     {{> drizzle.nav}}
     <div class="drizzle-Layout-main drizzle-u-cf">
       <div class="drizzle-u-pad drizzle-u-rhythm">
-        {{#block "body"}}
+        {{#block "main"}}
 
         {{/block}}
       </div>


### PR DESCRIPTION
This PR finishes out addressing #53.

Changes include:
- Update to point to latest `drizzle-builder`
- Update templates to use `body`/`main` instead of `wrapper`/`body`

cc: @tylersticka @erikjung @saralohr @nicolemors 
