### PR TITLE
Feature: use new helpers (data, pages, collections)

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "babel-preset-es2015": "^6.6.0",
     "core-gulp-tasks": "github:cloudfour/core-gulp-tasks#v2.0.0",
     "core-hbs-helpers": "github:cloudfour/core-hbs-helpers#v0.4.0",
-    "drizzle-builder": "0.0.5",
+    "drizzle-builder": "0.0.6",
     "eslint": "^2.7.0",
     "eslint-config-xo-space": "^0.12.0",
     "eslint-plugin-babel": "^3.2.0",

--- a/src/pages/demos/demo-example-1.hbs
+++ b/src/pages/demos/demo-example-1.hbs
@@ -11,7 +11,7 @@ styles:
 
 <h1>{{title}}</h1>
 
-{{#each drizzle.data.articles.contents}}
+{{#each (data "articles")}}
   <article>
     <header>
       <h2>{{title}}</h2>

--- a/src/pages/demos/demo-example-2.hbs
+++ b/src/pages/demos/demo-example-2.hbs
@@ -10,7 +10,7 @@ styles:
 
 <p>Data below courtesy of <a href="http://www.radfaces.com">Rad Faces</a>.</p>
 <ul>
-  {{#each drizzle.data.radfaces.contents}}
+  {{#each (data "radfaces")}}
     <li>{{first_name}} {{last_name}} from {{location}}</li>
   {{/each}}
 </ul>

--- a/src/pages/demos/index.hbs
+++ b/src/pages/demos/index.hbs
@@ -6,8 +6,6 @@ title: Demos
 
 <p>These are some demos.</p>
 
-{{#each drizzle.pages.demos}}
-  {{#compare @key "!==" "index"}}
-    {{> drizzle.page-item }}
-  {{/compare}}
+{{#each (pages "demos" ignore="index")}}
+  {{> drizzle.page-item }}
 {{/each}}

--- a/src/pages/docs/index.hbs
+++ b/src/pages/docs/index.hbs
@@ -5,9 +5,9 @@ title: Documentation
 <p>These are some docs.</p>
 
 <ul>
-  {{#each drizzle.pages.docs}}
-    {{#compare @key "!==" "index"}}
-      <li><a href="./{{@key}}.html">{{data.title}}</a></li>
-    {{/compare}}
+  {{#each (pages "docs" ignore="index")}}
+    <li>
+      <a href="{{baseurl}}/{{url}}">{{data.title}}</a>
+    </li>
   {{/each}}
 </ul>

--- a/src/pages/index.hbs
+++ b/src/pages/index.hbs
@@ -31,7 +31,7 @@ title: Overview
 
 <h3>Colors</h3>
 
-{{#each drizzle.data.colors.contents}}
+{{#each (data "colors")}}
   <h4 class="drizzle-u-capitalize">{{@key}}</h4>
   <ul class="drizzle-u-listInline">
     {{#each this}}

--- a/src/patterns/typography/headings.hbs
+++ b/src/patterns/typography/headings.hbs
@@ -9,7 +9,7 @@ labels:
 previewClass: drizzle-u-rhythm
 ---
 
-{{#with drizzle.data.specimens.contents}}
+{{#with (data "specimens")}}
   <h1>{{heading}}</h1>
   <h2>{{heading}}</h2>
   <h3>{{heading}}</h3>

--- a/src/patterns/typography/misc.hbs
+++ b/src/patterns/typography/misc.hbs
@@ -5,7 +5,7 @@ notes: |
   These are some misc elements.
 ---
 
-{{#with drizzle.data.specimens.contents}}
+{{#with (data "specimens")}}
   {{punctuation}}<br>
   {{characters}}<br>
   {{math}}<br>

--- a/src/patterns/typography/paragraphs.hbs
+++ b/src/patterns/typography/paragraphs.hbs
@@ -9,5 +9,5 @@ labels:
 
 {{!-- TODO: maybe a helper or something to shorten this path? --}}
 <p>
-  {{drizzle.data.specimens.contents.paragraph}}
+  {{data "specimens.paragraph"}}
 </p>

--- a/src/patterns/typography/paragraphs.hbs
+++ b/src/patterns/typography/paragraphs.hbs
@@ -7,7 +7,6 @@ labels:
   - inprogress
 ---
 
-{{!-- TODO: maybe a helper or something to shorten this path? --}}
 <p>
   {{data "specimens.paragraph"}}
 </p>

--- a/src/templates/drizzle/nav.hbs
+++ b/src/templates/drizzle/nav.hbs
@@ -1,3 +1,9 @@
+{{#*inline "nav-item"}}
+  <a class="drizzle-Nav-item" href="{{baseurl}}/{{url}}">
+    {{label}}
+  </a>
+{{/inline}}
+
 <div class="drizzle-Layout-nav drizzle-Nav" id="nav">
   <div class="drizzle-Nav-header">
     <a href="/">
@@ -11,99 +17,44 @@
   </div>
   <div class="drizzle-Nav-main">
     <ul class="drizzle-Nav-menu" id="nav-menu">
-      {{!-- WIP tree usage
-      <!--
-      {
-        pages: {
-          children: [
-            [Object],
-            [Object]
-          ],
-          items: [
-            [Object]
-          ]
-        },
-        collections: {
-          children: [
-            [Object],
-            [Object]
-          ]
-        }
-      }
-      -->
-      {{#with drizzle.tree}}
-        {{#each pages.items}}
-          {{log path}}
-        {{/each}}
-        {{#each collections.children}}
-          {{#each items}}
-            {{log path}}
-          {{/each}}
-        {{/each}}
-        {{#each pages.children}}
-          {{#each items}}
-            {{log path}}
-          {{/each}}
-        {{/each}}
-      {{/with}}
-      --}}
-
       {{!-- Top-level pages --}}
-      {{#each drizzle.pages}}
-        {{#if contents}}
-          <li>
-            <a class="drizzle-Nav-item" href="/{{@key}}.html">
-              {{data.title}}
-            </a>
-          </li>
-        {{/if}}
+      {{#each (pages)}}
+        <li>
+          {{> nav-item label=data.title}}
+        </li>
       {{/each}}
       {{!-- Patterns --}}
-      {{#each drizzle.patterns}}
+      {{#each (collections)}}
         <li>
-          <a class="drizzle-Nav-item" href="/patterns/{{@key}}.html">
-            {{collection.name}}
-          </a>
+          {{> nav-item label=name}}
         </li>
       {{/each}}
       {{!-- Demo pages --}}
-      {{#with drizzle.pages.demos}}
-        <li>
-          <a class="drizzle-Nav-item" href="/demos/index.html">
-            {{index.data.title}}
-          </a>
-          <ul class="drizzle-Nav-menu">
-            {{#each this}}
-              {{#compare @key "!==" "index"}}
-                <li>
-                  <a class="drizzle-Nav-item" href="/demos/{{@key}}.html">
-                    {{data.title}}
-                  </a>
-                </li>
-              {{/compare}}
-            {{/each}}
-          </ul>
-        </li>
-      {{/with}}
+      <li>
+        {{#with (page "demos/index")}}
+          {{> nav-item label=data.title}}
+        {{/with}}
+        <ul class="drizzle-Nav-menu">
+          {{#each (pages "demos" ignore="index")}}
+            <li>
+              {{> nav-item label=data.title}}
+            </li>
+          {{/each}}
+        </ul>
+      </li>
       {{!-- Docs pages --}}
-      {{#with drizzle.pages.docs}}
-        <li>
-          <a class="drizzle-Nav-item" href="/docs/index.html">
-            {{index.data.title}}
-          </a>
-          <ul class="drizzle-Nav-menu">
-            {{#each this}}
-              {{#compare @key "!==" "index"}}
-                <li>
-                  <a class="drizzle-Nav-item" href="/docs/{{@key}}.html">
-                    {{data.title}}
-                  </a>
-                </li>
-              {{/compare}}
-            {{/each}}
-          </ul>
-        </li>
-      {{/with}}
+      <li>
+        {{#with (page "docs/index")}}
+          {{> nav-item label=data.title}}
+        {{/with}}
+        <ul class="drizzle-Nav-menu">
+          {{#each (pages "docs" ignore="index")}}
+            <li>
+              {{> nav-item label=data.title}}
+            </li>
+          {{/each}}
+        </ul>
+      </li>
     </ul>
   </div>
 </div>

--- a/src/templates/drizzle/page-item.hbs
+++ b/src/templates/drizzle/page-item.hbs
@@ -1,13 +1,15 @@
 <div class="drizzle-Item">
   <div class="drizzle-Grid drizzle-Grid--withGutter">
     <div class="drizzle-Grid-cell drizzle-u-marginBottom drizzle-u-md-size1of3">
-      <div class="drizzle-FrameThumb" data-drizzle-append-iframe="./{{@key}}.html" aria-hidden="true">
-        <a href="./{{@key}}.html"></a>
+      <div class="drizzle-FrameThumb"
+       data-drizzle-append-iframe="{{baseurl}}/{{url}}"
+       aria-hidden="true">
+        <a href="{{baseurl}}/{{url}}"></a>
       </div>
     </div>
     <div class="drizzle-Grid-cell drizzle-u-md-size2of3">
       {{#> drizzle.labelheader tag="h4" labels=data.labels}}
-        <a href="./{{@key}}.html">{{data.title}}</a>
+        <a href="{{baseurl}}/{{url}}">{{data.title}}</a>
       {{/drizzle.labelheader}}
       {{#if data.notes}}
         <div class="drizzle-Item-notes drizzle-u-rhythm">


### PR DESCRIPTION
Re:
https://github.com/cloudfour/drizzle-builder/pull/91
https://github.com/cloudfour/drizzle-builder/pull/88
https://github.com/cloudfour/drizzle-builder/pull/87
#23
#42

This applies the new `data`, `pages`, `page`, and `collections` helpers to the existing templates.

/CC @tylersticka @nicolemors @saralohr 
