### PR TITLE
Feature: use `{{baseurl}}`

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "babel-preset-es2015": "^6.6.0",
     "core-gulp-tasks": "github:cloudfour/core-gulp-tasks#v2.0.0",
     "core-hbs-helpers": "github:cloudfour/core-hbs-helpers#v0.4.0",
-    "drizzle-builder": "0.0.6",
+    "drizzle-builder": "0.0.7",
     "eslint": "^2.7.0",
     "eslint-config-xo-space": "^0.12.0",
     "eslint-plugin-babel": "^3.2.0",

--- a/src/pages/docs/index.hbs
+++ b/src/pages/docs/index.hbs
@@ -7,7 +7,7 @@ title: Documentation
 <ul>
   {{#each (pages "docs" ignore="index")}}
     <li>
-      <a href="{{baseurl}}/{{url}}">{{data.title}}</a>
+      <a href="{{@root.baseurl}}/{{url}}">{{data.title}}</a>
     </li>
   {{/each}}
 </ul>

--- a/src/pages/index.hbs
+++ b/src/pages/index.hbs
@@ -13,16 +13,16 @@ title: Overview
 
 <h3>Sections</h3>
 <dl>
-  <dt><a href="/patterns/typography.html">Typography</a></dt>
+  <dt><a href="{{@root.baseurl}}/patterns/typography.html">Typography</a></dt>
   <dd class="drizzle-u-padBottom">
     Examples of foundational typographic elements like headings, paragraphs
     and lists.
   </dd>
-  <dt><a href="/docs">Docs</a></dt>
+  <dt><a href="{{@root.baseurl}}/docs">Docs</a></dt>
   <dd class="drizzle-u-padBottom">
     General documentation of naming conventions and template usage.
   </dd>
-  <dt><a href="/demos">Demos</a></dt>
+  <dt><a href="{{@root.baseurl}}/demos">Demos</a></dt>
   <dd class="drizzle-u-padBottom">
     A collection of mockups, demonstrations, proofs-of-concept or
     anything else that might not be production-ready.

--- a/src/templates/blank.hbs
+++ b/src/templates/blank.hbs
@@ -12,7 +12,7 @@
         <title>{{data "project.title"}}</title>
       {{/if}}
       {{#each styles}}
-        <link rel="stylesheet" href="{{baseurl}}/assets/toolkit/styles/{{this}}.css">
+        <link rel="stylesheet" href="{{@root.baseurl}}/assets/toolkit/styles/{{this}}.css">
       {{/each}}
     {{/block}}
   </head>

--- a/src/templates/default.hbs
+++ b/src/templates/default.hbs
@@ -1,7 +1,7 @@
 {{#extend "blank" htmlclass="drizzle-Layout" bodyclass="drizzle-Layout-body"}}
   {{#content "head" mode="append"}}
-    <link rel="stylesheet" href="{{baseurl}}/assets/drizzle/styles/drizzle.css">
-    <link rel="stylesheet" href="{{baseurl}}/assets/toolkit/styles/toolkit.css">
+    <link rel="stylesheet" href="{{@root.baseurl}}/assets/drizzle/styles/drizzle.css">
+    <link rel="stylesheet" href="{{@root.baseurl}}/assets/toolkit/styles/toolkit.css">
   {{/content}}
   {{#content "body"}}
     {{> drizzle.nav}}
@@ -14,7 +14,7 @@
     </div>
   {{/content}}
   {{#content "foot"}}
-    <script src="{{baseurl}}/assets/drizzle/scripts/drizzle.js"></script>
-    <script src="{{baseurl}}/assets/toolkit/scripts/toolkit.js"></script>
+    <script src="{{@root.baseurl}}/assets/drizzle/scripts/drizzle.js"></script>
+    <script src="{{@root.baseurl}}/assets/toolkit/scripts/toolkit.js"></script>
   {{/content}}
 {{/extend}}

--- a/src/templates/drizzle/nav.hbs
+++ b/src/templates/drizzle/nav.hbs
@@ -1,12 +1,12 @@
 {{#*inline "nav-item"}}
-  <a class="drizzle-Nav-item" href="{{baseurl}}/{{url}}">
+  <a class="drizzle-Nav-item" href="{{@root.baseurl}}/{{url}}">
     {{label}}
   </a>
 {{/inline}}
 
 <div class="drizzle-Layout-nav drizzle-Nav" id="nav">
   <div class="drizzle-Nav-header">
-    <a href="/">
+    <a href="{{baseurl}}/">
       {{> drizzle.logo}}
     </a>
     <a class="drizzle-Nav-header-toggle" href="#nav">

--- a/src/templates/drizzle/nav.hbs
+++ b/src/templates/drizzle/nav.hbs
@@ -6,7 +6,7 @@
 
 <div class="drizzle-Layout-nav drizzle-Nav" id="nav">
   <div class="drizzle-Nav-header">
-    <a href="{{baseurl}}/">
+    <a href="{{@root.baseurl}}/">
       {{> drizzle.logo}}
     </a>
     <a class="drizzle-Nav-header-toggle" href="#nav">

--- a/src/templates/drizzle/page-item.hbs
+++ b/src/templates/drizzle/page-item.hbs
@@ -2,14 +2,14 @@
   <div class="drizzle-Grid drizzle-Grid--withGutter">
     <div class="drizzle-Grid-cell drizzle-u-marginBottom drizzle-u-md-size1of3">
       <div class="drizzle-FrameThumb"
-       data-drizzle-append-iframe="{{baseurl}}/{{url}}"
+       data-drizzle-append-iframe="{{@root.baseurl}}/{{url}}"
        aria-hidden="true">
-        <a href="{{baseurl}}/{{url}}"></a>
+        <a href="{{@root.baseurl}}/{{url}}"></a>
       </div>
     </div>
     <div class="drizzle-Grid-cell drizzle-u-md-size2of3">
       {{#> drizzle.labelheader tag="h4" labels=data.labels}}
-        <a href="{{baseurl}}/{{url}}">{{data.title}}</a>
+        <a href="{{@root.baseurl}}/{{url}}">{{data.title}}</a>
       {{/drizzle.labelheader}}
       {{#if data.notes}}
         <div class="drizzle-Item-notes drizzle-u-rhythm">


### PR DESCRIPTION
Re: #43, https://github.com/cloudfour/drizzle-builder/pull/92

This updates to the latest version of `drizzle-builder` and normalizes all instances of `{{baseurl}}`. 

Because there are some cases where `@root` is needed to resolve the variable context (e.g. within `pages` helper loops), I've used it on all instances to avoid confusion about when it's required.

/CC @tylersticka
