### PR TITLE
Change item partial to use `name` vs. `data.name`

### DIFF
--- a/src/templates/drizzle/item.hbs
+++ b/src/templates/drizzle/item.hbs
@@ -1,8 +1,8 @@
 <div class="drizzle-Item drizzle-u-rhythm">
   {{!-- Header, labels --}}
   <div class="drizzle-u-marginEnds">
-    {{#> drizzle.labelheader tag="h2" id=(toSlug data.name) labels=data.labels}}
-      {{data.name}}
+    {{#> drizzle.labelheader tag="h2" id=(toSlug name) labels=data.labels}}
+      {{name}}
     {{/drizzle.labelheader}}
   </div>
   {{!-- Notes --}}


### PR DESCRIPTION
Re: #63 

This makes it so `name` is no longer required in pattern YFM in order to display a heading on the collection page.

/CC @mrgerardorodriguez 
