### PR TITLE
Feature: Add a new task to deploy demo to GitHub Pages

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+demo
 dist
 node_modules
 npm-debug.log

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -2,6 +2,7 @@
 
 const drizzle = require('drizzle-builder');
 const gulp = require('gulp');
+const ghPages = require('gulp-gh-pages');
 const helpers = require('core-hbs-helpers');
 const tasks = require('core-gulp-tasks');
 const env = require('gulp-util').env;
@@ -42,6 +43,18 @@ gulp.task('frontend', [
 gulp.task('build', ['clean'], done => {
   gulp.start('frontend');
   done();
+});
+
+/**
+ * Register demo task (deploy output to GitHub Pages)
+ * NOTE: Run this after building.
+ */
+gulp.task('demo', () => {
+  const buildDest = `${config.drizzle.dest.pages}/**/*`;
+  return gulp.src(buildDest)
+    .pipe(ghPages({
+      cacheDir: 'demo'
+    }));
 });
 
 // Register default task

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "eslint-config-xo-space": "^0.12.0",
     "eslint-plugin-babel": "^3.2.0",
     "gulp": "^3.9.1",
+    "gulp-gh-pages": "^0.5.4",
     "gulp-util": "^3.0.7",
     "postcss-cssnext": "^2.5.2",
     "prismjs": "^1.4.1",


### PR DESCRIPTION
Re: #70 

This adds the **Option B** solution.

``` sh
gulp build
gulp demo
```

The contents of `.dist` will be committed and pushed to the `gh-pages` branch, and viewable at http://cloudfour.github.io/drizzle/

**NOTE**: I first attempted to have the `cacheDir` (`demo`) be the same as `dist`, but the Gulp plugin had issues with that. I might be possible though, for future improvement.
