### PR TITLE
Chore: update deps

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -3,8 +3,8 @@
 const drizzle = require('drizzle-builder');
 const gulp = require('gulp');
 const ghPages = require('gulp-gh-pages');
-const helpers = require('core-hbs-helpers');
-const tasks = require('core-gulp-tasks');
+const helpers = require('@cloudfour/hbs-helpers');
+const tasks = require('@cloudfour/gulp-tasks');
 const env = require('gulp-util').env;
 const config = require('./config');
 

--- a/package.json
+++ b/package.json
@@ -26,12 +26,12 @@
     "node": ">=4.0.0"
   },
   "devDependencies": {
+    "@cloudfour/gulp-tasks": "^2.0.1",
+    "@cloudfour/hbs-helpers": "^0.6.1",
     "babel-core": "^6.7.6",
     "babel-eslint": "^6.0.2",
     "babel-loader": "^6.2.4",
     "babel-preset-es2015": "^6.6.0",
-    "core-gulp-tasks": "github:cloudfour/core-gulp-tasks#v2.0.0",
-    "core-hbs-helpers": "github:cloudfour/core-hbs-helpers#v0.4.0",
     "drizzle-builder": "0.0.9",
     "eslint": "^2.7.0",
     "eslint-config-xo-space": "^0.12.0",

--- a/src/patterns/elements/typographic/misc.hbs
+++ b/src/patterns/elements/typographic/misc.hbs
@@ -6,10 +6,10 @@ notes: |
 ---
 
 {{#with (data "specimens")}}
-  {{punctuation}}<br>
-  {{characters}}<br>
-  {{math}}<br>
-  {{currencies}}<br>
-  {{arrows}}<br>
-  {{units}}
+  {{this.punctuation}}<br>
+  {{this.characters}}<br>
+  {{this.math}}<br>
+  {{this.currencies}}<br>
+  {{this.arrows}}<br>
+  {{this.units}}
 {{/with}}


### PR DESCRIPTION
Re: #69 

This updates our dependencies for the "core" helpers and Gulp tasks. They are now published on npm and referenced accordingly on our package info and Gulpfile.

There was also a little tweak needed in one of the pattern templates due to the new `{{math}}` helper.
