### PR TITLE
Bump builder version

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "babel-loader": "^6.2.4",
     "babel-preset-es2015": "^6.6.0",
     "doctoc": "^1.1.1",
-    "drizzle-builder": "0.0.9",
+    "drizzle-builder": "0.0.10",
     "eslint": "^2.7.0",
     "eslint-config-xo-space": "^0.12.0",
     "eslint-plugin-babel": "^3.2.0",


### PR DESCRIPTION
This bumps the builder version to `0.0.10`, which incorporates a fix @tylersticka made to address paths on Windows, as well as another fix for an unrelated failing unit test.